### PR TITLE
Added placekey to entry forms

### DIFF
--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -166,7 +166,7 @@
         );
 
         let satelliteLayer = L.tileLayer(
-            'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+            'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
                 attribution: `&copy; <a href="http://www.esri.com/">Esri</a>,
                  i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community`,
                 maxZoom: 18,

--- a/src/components/scd/Content.svelte
+++ b/src/components/scd/Content.svelte
@@ -36,6 +36,14 @@
             data.description = undefined;
         }
     }
+
+    function togglePlacekey(event) {
+        if (event.target.checked) {
+            data.placekey = '';
+        } else {
+            data.placekey = undefined;
+        }
+    }
 </script>
 
 
@@ -63,6 +71,14 @@
 </div>
 
 <Keywords bind:data={data.keywords} />
+
+<div>
+    <label for="contentplacekey">
+        <input type="checkbox" checked="{data.placekey !== undefined}" on:change={togglePlacekey} />
+        <span>Placekey</span>
+    </label>
+    <input id="contentplacekey" disabled="{data.placekey === undefined}" bind:value={data.placekey} />
+</div>
 
 <References bind:data={data.refs} on:refsUpdated={() => dispatch('refsUpdated')} />
 


### PR DESCRIPTION
[placekey](https://www.placekey.io/) was added to the spatial content record as an optional parameter. Since it is currently fully supported only in the US, it consists just as a simple string field. When support for placekey grows internationally, it will be added to the map also.